### PR TITLE
use fallbackPalette if MaterialYou is not supported

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,18 @@ export const useMaterialYou = ({ fallbackPalette }: { fallbackPalette?: Material
 
     if (stateRef.current === null) {
         const _refresh = async () => {
-            const _palette = await getPalette();
+
+            let _palette = initialPalette;
+
+            try {
+                _palette = await getPalette();
+            }
+            catch(err){
+                console.error(err);
+                if (!stateRef.current.isSupported && fallbackPalette){
+                    _palette = fallbackPalette;
+                }
+            }
 
             if (_palette && _palette.system_accent1 && _palette.system_accent2 && _palette.system_accent3 && _palette.system_neutral1 && _palette.system_neutral2) {
                 setPalette(_palette)
@@ -122,16 +133,11 @@ export const useMaterialYouService = () =>
  * Returns a promise with Material You palette generated from the devices wallpaper.
  */
 export const getPalette = async () => {
-    try {
-        const palette = await RNMaterialYouModule?.getMaterialYouPalettePromise();
-        if (!palette)
-            throw new Error("Material You is not supported on this device.");
+    const palette = await RNMaterialYouModule?.getMaterialYouPalettePromise();
+    if (!palette)
+        throw new Error("Material You is not supported on this device.");
 
-        return { ...palette }
-    } catch (err) {
-        console.error(err);
-        return getInitialPalette();
-    }
+    return { ...palette }
 }
 
 /**


### PR DESCRIPTION
This allows developer to pass custom pallete's to `MaterialYouService` and such.
Currently, it works but on invoking `_refresh()`,  `fallbackPallete` gets reset to default.

PR contain changes to persist custom `fallbackPalette` during refresh by setting `fallbackPalette` as `palette` if Android is unsupported (<= A11/API30) and `fallbackPallete` exists.

Tested on Android 11 (Working as expected) and Android 12 (No Side effects).

 